### PR TITLE
feat: 初期セットアップとアプリケーション構造の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,118 @@
+# Toki - AI日記アプリ
+
+AIを活用した日記アプリケーションのモノレポです。
+
+## 技術スタック
+
+- **フロントエンド**: Next.js 14 (App Router), React 18, TypeScript
+- **バックエンド**: Node.js, Express, Apollo Server (GraphQL)
+- **モバイル**: Flutter
+- **スタイリング**: Tailwind CSS
+- **状態管理**: Zustand
+- **データベース**: Firebase
+- **AI**: OpenAI API
+
+## セットアップ
+
+### 前提条件
+
+- Node.js >= 18.0.0
+- npm >= 9.0.0 または yarn >= 1.22.0
+- Flutter (モバイルアプリ開発用)
+
+### インストール
+
+```bash
+# 依存関係のインストール
+yarn install
+
+# モバイルアプリの依存関係（Flutter）
+cd apps/mobile && flutter pub get
+```
+
+### 開発サーバーの起動
+
+```bash
+# WebアプリとAPIサーバーを同時起動
+yarn dev
+
+# 個別起動
+yarn dev:web    # Webアプリ (http://localhost:3000)
+yarn dev:api    # APIサーバー (http://localhost:4000)
+```
+
+### テスト
+
+```bash
+# 全テスト実行
+yarn test
+
+# 個別テスト
+yarn test:web   # Webアプリのテスト
+yarn test:api   # APIのテスト
+```
+
+### リント
+
+```bash
+# 全リント実行
+yarn lint
+
+# 個別リント
+yarn lint:web   # Webアプリのリント
+yarn lint:api   # APIのリント
+```
+
+### ビルド
+
+```bash
+# 全ビルド
+yarn build
+
+# 個別ビルド
+yarn build:web  # Webアプリのビルド
+yarn build:api  # APIのビルド
+```
+
+## プロジェクト構造
+
+```
+toki/
+├── apps/
+│   ├── web/          # Next.js Webアプリケーション
+│   └── mobile/       # Flutter モバイルアプリ
+├── packages/
+│   ├── api/          # GraphQL APIサーバー
+│   ├── shared/       # 共有型定義とユーティリティ
+│   ├── db/           # データベース関連
+│   └── ai/           # AI機能
+└── docs/             # ドキュメント
+```
+
+## 開発ガイド
+
+### 新しい機能の追加
+
+1. 適切なパッケージ/アプリに機能を追加
+2. 型定義を `packages/shared` に追加
+3. GraphQLスキーマを更新
+4. テストを追加
+5. リントを実行してコード品質を確認
+
+### コミットメッセージ
+
+- `feat:` 新機能
+- `fix:` バグ修正
+- `docs:` ドキュメント更新
+- `style:` コードスタイル修正
+- `refactor:` リファクタリング
+- `test:` テスト追加・修正
+- `chore:` その他の変更
+
+## ライセンス
+
+MIT
+
 # Toki
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,9 +1,3 @@
 {
-  "extends": ["next/core-web-vitals", "@typescript-eslint/recommended"],
-  "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint"],
-  "rules": {
-    "@typescript-eslint/no-unused-vars": "warn",
-    "@typescript-eslint/no-explicit-any": "warn"
-  }
+  "extends": ["next/core-web-vitals"]
 } 

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["next/core-web-vitals", "@typescript-eslint/recommended"],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "@typescript-eslint/no-unused-vars": "warn",
+    "@typescript-eslint/no-explicit-any": "warn"
+  }
+} 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,27 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --foreground-rgb: 0, 0, 0;
+  --background-start-rgb: 214, 219, 220;
+  --background-end-rgb: 255, 255, 255;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --foreground-rgb: 255, 255, 255;
+    --background-start-rgb: 0, 0, 0;
+    --background-end-rgb: 0, 0, 0;
+  }
+}
+
+body {
+  color: rgb(var(--foreground-rgb));
+  background: linear-gradient(
+      to bottom,
+      transparent,
+      rgb(var(--background-end-rgb))
+    )
+    rgb(var(--background-start-rgb));
+} 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next'
+import { Inter } from 'next/font/google'
+import './globals.css'
+
+const inter = Inter({ subsets: ['latin'] })
+
+export const metadata: Metadata = {
+  title: 'Toki - AI日記アプリ',
+  description: 'AIを活用した日記アプリケーション',
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="ja">
+      <body className={inter.className}>{children}</body>
+    </html>
+  )
+} 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,23 @@
+export default function Home() {
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-4xl font-bold text-gray-900 mb-4">
+          Toki - AI日記アプリ
+        </h1>
+        <p className="text-lg text-gray-600 mb-8">
+          AIを活用して日記を書く、新しい体験を始めましょう。
+        </p>
+        <div className="bg-white rounded-lg shadow-md p-6">
+          <h2 className="text-2xl font-semibold mb-4">機能</h2>
+          <ul className="space-y-2 text-gray-700">
+            <li>• AIによる日記の自動分析</li>
+            <li>• 感情分析とトレンド追跡</li>
+            <li>• 美しいUI/UX</li>
+            <li>• モバイル対応</li>
+          </ul>
+        </div>
+      </div>
+    </main>
+  )
+} 

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+} 

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,0 +1,20 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {
+      backgroundImage: {
+        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
+        'gradient-conic':
+          'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
+      },
+    },
+  },
+  plugins: [
+    require('@tailwindcss/typography'),
+  ],
+} 

--- a/packages/api/.eslintrc.json
+++ b/packages/api/.eslintrc.json
@@ -1,15 +1,19 @@
 {
   "env": {
     "node": true,
-    "es6": true
+    "es6": true,
+    "jest": true
   },
   "extends": ["eslint:recommended"],
+  "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2020,
     "sourceType": "module"
   },
+  "plugins": ["@typescript-eslint"],
   "rules": {
-    "no-unused-vars": "warn",
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": "warn",
     "no-console": "off"
   }
 } 

--- a/packages/api/.eslintrc.json
+++ b/packages/api/.eslintrc.json
@@ -1,13 +1,15 @@
 {
-  "extends": ["@typescript-eslint/recommended"],
-  "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint"],
-  "rules": {
-    "@typescript-eslint/no-unused-vars": "warn",
-    "@typescript-eslint/no-explicit-any": "warn"
-  },
   "env": {
     "node": true,
     "es6": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "rules": {
+    "no-unused-vars": "warn",
+    "no-console": "off"
   }
 } 

--- a/packages/api/.eslintrc.json
+++ b/packages/api/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["@typescript-eslint/recommended"],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "@typescript-eslint/no-unused-vars": "warn",
+    "@typescript-eslint/no-explicit-any": "warn"
+  },
+  "env": {
+    "node": true,
+    "es6": true
+  }
+} 

--- a/packages/api/jest.config.js
+++ b/packages/api/jest.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+  ],
+}; 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "jest",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint src --ext .ts",
     "codegen": "cd ../shared && npm run codegen"
   },
   "dependencies": {

--- a/packages/api/src/__tests__/resolvers.test.ts
+++ b/packages/api/src/__tests__/resolvers.test.ts
@@ -1,0 +1,25 @@
+import { resolvers } from '../resolvers';
+
+describe('Resolvers', () => {
+  describe('Query', () => {
+    it('should return hello message', () => {
+      const result = resolvers.Query.hello();
+      expect(result).toBe('Hello from Toki API!');
+    });
+
+    it('should return health status', () => {
+      const result = resolvers.Query.health();
+      expect(result).toHaveProperty('status', 'ok');
+      expect(result).toHaveProperty('timestamp');
+      expect(typeof result.timestamp).toBe('string');
+    });
+  });
+
+  describe('Mutation', () => {
+    it('should echo message', () => {
+      const message = 'test message';
+      const result = resolvers.Mutation.echo(null, { message });
+      expect(result).toBe(`Echo: ${message}`);
+    });
+  });
+}); 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,0 +1,42 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import compression from 'compression';
+import { ApolloServer } from 'apollo-server-express';
+import { typeDefs } from './schema';
+import { resolvers } from './resolvers';
+
+const app = express();
+const PORT = process.env.PORT || 4000;
+
+// ミドルウェアの設定
+app.use(helmet());
+app.use(cors());
+app.use(compression());
+app.use(express.json());
+
+// Apollo Serverの設定
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  context: ({ req }) => ({
+    // コンテキストにリクエスト情報を追加
+    req,
+  }),
+});
+
+async function startServer() {
+  await server.start();
+  server.applyMiddleware({ app, path: '/graphql' });
+
+  app.get('/health', (req, res) => {
+    res.json({ status: 'ok', timestamp: new Date().toISOString() });
+  });
+
+  app.listen(PORT, () => {
+    console.log(`🚀 Server ready at http://localhost:${PORT}${server.graphqlPath}`);
+    console.log(`🏥 Health check available at http://localhost:${PORT}/health`);
+  });
+}
+
+startServer().catch(console.error); 

--- a/packages/api/src/resolvers.ts
+++ b/packages/api/src/resolvers.ts
@@ -7,6 +7,6 @@ export const resolvers = {
     }),
   },
   Mutation: {
-    echo: (_: any, { message }: { message: string }) => `Echo: ${message}`,
+    echo: (_: unknown, { message }: { message: string }) => `Echo: ${message}`,
   },
 }; 

--- a/packages/api/src/resolvers.ts
+++ b/packages/api/src/resolvers.ts
@@ -1,0 +1,12 @@
+export const resolvers = {
+  Query: {
+    hello: () => 'Hello from Toki API!',
+    health: () => ({
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+    }),
+  },
+  Mutation: {
+    echo: (_: any, { message }: { message: string }) => `Echo: ${message}`,
+  },
+}; 

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -1,0 +1,17 @@
+import { gql } from 'apollo-server-express';
+
+export const typeDefs = gql`
+  type Query {
+    hello: String
+    health: HealthStatus
+  }
+
+  type Mutation {
+    echo(message: String!): String
+  }
+
+  type HealthStatus {
+    status: String!
+    timestamp: String!
+  }
+`; 


### PR DESCRIPTION
Toki AI日記アプリの初期セットアップと基本的なアプリケーション構造を追加しました。yarn v1対応、Next.js App Router、GraphQL APIサーバーの基本構造、ESLint/Jest設定を含みます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the "Toki" AI diary application with an initial web interface, including a homepage outlining app features and a global layout styled with Tailwind CSS.
  - Added support for light and dark mode themes with adaptive styling.
  - Implemented a basic GraphQL API server with queries for greetings and health checks, and a mutation for echoing messages.

- **Documentation**
  - Added a comprehensive README (primarily in Japanese) detailing project overview, technology stack, setup, development workflow, and license.

- **Chores**
  - Added ESLint and PostCSS configurations for code quality and CSS processing.
  - Set up Tailwind CSS and Typography plugin for enhanced styling.
  - Added Jest configuration and initial test suite for API resolvers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->